### PR TITLE
Add flow config and environment __DEV__

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
-  "presets": ["env"],
+  "presets": ["env", "flow"],
   "plugins": [
     ["transform-react-jsx", {
       "pragma": "createElement"

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,11 @@
+[ignore]
+
+[include]
+
+[libs]
+
+[lints]
+
+[options]
+
+[strict]

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     }
   ],
   "scripts": {
-    "build": "npm-run-all --silent rollup:umd -p minify:umd -s size",
+    "build": "NODE_ENV=production npm-run-all --silent rollup:umd -p minify:umd -s size",
+    "dev": "NODE_ENV=development npm-run-all --silent rollup:umd",
     "clean": "rimraf build && mkdirp build",
     "rollup:umd": "rollup -c",
     "minify:umd": "uglifyjs build/fiber.js -cm -o build/fiber.js",
@@ -52,11 +53,13 @@
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-react-jsx": "^6.24.1",
     "babel-preset-env": "^1.6.0",
+    "babel-preset-flow": "^6.23.0",
     "babelrc-rollup": "^3.0.0",
     "bundlesize": "^0.15.3",
     "coveralls": "^3.0.0",
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-plugin-import": "^2.8.0",
+    "flow-bin": "^0.58.0",
     "gzip-size-cli": "^2.1.0",
     "jest": "^21.2.1",
     "mkdirp": "^0.5.1",
@@ -65,12 +68,17 @@
     "rollup": "^0.50.0",
     "rollup-plugin-babel": "^3.0.2",
     "rollup-plugin-eslint": "^4.0.0",
+    "rollup-plugin-flow": "^1.1.1",
+    "rollup-plugin-replace": "^2.0.0",
     "uglify-js": "^3.1.2"
   },
   "jest": {
     "collectCoverageFrom": [
       "src/**/*.js"
-    ]
+    ],
+    "globals": {
+      "__DEV__": false
+    }
   },
   "bundlesize": [
     {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,8 @@
 import babel from 'rollup-plugin-babel';
 import babelrc from 'babelrc-rollup';
 import eslint from 'rollup-plugin-eslint';
+import replace from 'rollup-plugin-replace';
+import flow from 'rollup-plugin-flow';
 
 const babelConfig = {
   'presets': [
@@ -22,6 +24,11 @@ export default {
     sourcemap: true
   },
   plugins: [
+    flow(),
+    replace({
+      exclude: 'node_modules/**',
+      __DEV__: JSON.stringify(process.env.NODE_ENV == 'development'),
+    }),
     eslint({
       exclude: [
         'node_modules/**'
@@ -34,6 +41,6 @@ export default {
       plugins: [
         "transform-object-rest-spread"
       ]
-    }))
+    })),
   ]
 };

--- a/src/isomorphic/render.js
+++ b/src/isomorphic/render.js
@@ -1,13 +1,21 @@
+/* @flow */
+
 import { buildComponentFromVNode } from './createComponent'
 
 let component;
+
+type Vnode = {
+  nodeName: string | ?void,
+  attributes: Array<any> | void,
+  children: string | Array<any> | void
+};
 
 /**
  * Abstraction rule rendering and provide an
  * API to create any renderer on top of that.
  */
-const renderFactory = (vnode, callback) => {
-  if (isNull(vnode) || isBoolean(vnode)) vnode = '';
+const renderFactory = (vnode: Vnode, callback: Function): (Object | string) => {
+  if (isNull(vnode) || isBoolean(vnode)) return callback('');
 
 	if (isString(vnode) || isNumber(vnode)) return callback(vnode);
 
@@ -32,7 +40,7 @@ const renderFactory = (vnode, callback) => {
  * @return {boolean}
  * @internal
  */
-const isBoolean = (vnode) => {
+const isBoolean = (vnode: any): boolean => {
 	if (typeof vnode === 'boolean') return true;
 	return false;
 }
@@ -44,7 +52,7 @@ const isBoolean = (vnode) => {
  * @return {boolean}
  * @internal
  */
-const isNull = (vnode) => {
+const isNull = (vnode: any): boolean => {
   if (vnode == null) return true;
   return false;
 }
@@ -55,7 +63,7 @@ const isNull = (vnode) => {
  * @return {boolean}
  * @internal
  */
-const isString = (vnode) => {
+const isString = (vnode: any): boolean => {
 	if (typeof vnode === 'string') return true;
 	return false;
 }
@@ -66,7 +74,7 @@ const isString = (vnode) => {
  * @return {boolean}
  * @internal
  */
-const isNumber = (vnode) => {
+const isNumber = (vnode: any): boolean => {
 	if (typeof vnode === 'number') return true;
 	return false;
 }
@@ -77,7 +85,7 @@ const isNumber = (vnode) => {
  * @return {boolean}
  * @internal
  */
-const isFunction = (vnode) => {
+const isFunction = (vnode: any): boolean => {
 	if (typeof vnode === 'function') return true;
 	return false;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -418,6 +418,10 @@ babel-plugin-syntax-exponentiation-operator@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"
 
+babel-plugin-syntax-flow@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz#4c3ab20a2af26aa20cd25995c398c4eb70310c8d"
+
 babel-plugin-syntax-jsx@^6.8.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
@@ -614,6 +618,13 @@ babel-plugin-transform-exponentiation-operator@^6.22.0:
     babel-plugin-syntax-exponentiation-operator "^6.8.0"
     babel-runtime "^6.22.0"
 
+babel-plugin-transform-flow-strip-types@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz#84cb672935d43714fdc32bce84568d87441cf7cf"
+  dependencies:
+    babel-plugin-syntax-flow "^6.18.0"
+    babel-runtime "^6.22.0"
+
 babel-plugin-transform-object-rest-spread@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"
@@ -685,6 +696,12 @@ babel-preset-env@^1.6.0:
     invariant "^2.2.2"
     semver "^5.3.0"
 
+babel-preset-flow@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz#e71218887085ae9a24b5be4169affb599816c49d"
+  dependencies:
+    babel-plugin-transform-flow-strip-types "^6.22.0"
+
 babel-preset-jest@^21.2.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-21.2.0.tgz#ff9d2bce08abd98e8a36d9a8a5189b9173b85638"
@@ -750,7 +767,7 @@ babelrc-rollup@^3.0.0:
   dependencies:
     resolve "^1.1.7"
 
-babylon@^6.18.0:
+babylon@^6.15.0, babylon@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
 
@@ -1495,6 +1512,17 @@ flat-cache@^1.2.1:
     del "^2.0.2"
     graceful-fs "^4.1.2"
     write "^0.2.1"
+
+flow-bin@^0.58.0:
+  version "0.58.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.58.0.tgz#62d5a776589419e5656800a0e5230a5e585ca65e"
+
+flow-remove-types@^1.1.0:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/flow-remove-types/-/flow-remove-types-1.2.3.tgz#6131aefc7da43364bb8b479758c9dec7735d1a18"
+  dependencies:
+    babylon "^6.15.0"
+    vlq "^0.2.1"
 
 follow-redirects@1.0.0:
   version "1.0.0"
@@ -2511,6 +2539,12 @@ lru-cache@^4.0.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
+magic-string@^0.22.4:
+  version "0.22.4"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.22.4.tgz#31039b4e40366395618c1d6cf8193c53917475ff"
+  dependencies:
+    vlq "^0.2.1"
+
 makeerror@1.0.x:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
@@ -3245,7 +3279,22 @@ rollup-plugin-eslint@^4.0.0:
     eslint "^4.1.1"
     rollup-pluginutils "^2.0.1"
 
-rollup-pluginutils@^1.5.0:
+rollup-plugin-flow@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-flow/-/rollup-plugin-flow-1.1.1.tgz#6ce568f1dd559666b77ab76b4bae251407528db6"
+  dependencies:
+    flow-remove-types "^1.1.0"
+    rollup-pluginutils "^1.5.1"
+
+rollup-plugin-replace@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-replace/-/rollup-plugin-replace-2.0.0.tgz#19074089c8ed57184b8cc64e967a03d095119277"
+  dependencies:
+    magic-string "^0.22.4"
+    minimatch "^3.0.2"
+    rollup-pluginutils "^2.0.1"
+
+rollup-pluginutils@^1.5.0, rollup-pluginutils@^1.5.1:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz#1e156e778f94b7255bfa1b3d0178be8f5c552408"
   dependencies:
@@ -3678,6 +3727,10 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+vlq@^0.2.1:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/vlq/-/vlq-0.2.3.tgz#8f3e4328cf63b1540c0d67e1b2778386f8975b26"
 
 walker@~1.0.5:
   version "1.0.7"


### PR DESCRIPTION
## Use of flow
I am testing the use of flow on Fiber and seems to be very promising, to know more information of him access [here](https://flow.org/en/). What do you think of this?

- [ ] `isomorphic/FiberComponent`
- [ ] `isomorphic/FiberCreateComponent`
- [ ] `isomorphic/FiberElement`
- [X] `isomorphic/FiberRender`
- [ ] `isomorphic/FiberUpdateQueue`
- [ ] `renderers/dom/FiberDOMEvents`
- [ ] `renderers/dom/FiberDOMRender`

To check flow errors, run `yarn run flow`.

## Use of `__DEV__`
I added a configuration so that we can use the `__DEV__` variable to display information in a block, such as error messages or warnings. Things we do not want in a production environment.

**Example**:
```javascript
if (__DEV__) {
    console.log('In development');
}
```

Blocks that use `__DEV__` are removed when compiled for production.